### PR TITLE
Add registry prod url for basePath to work

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,4 +6,13 @@ module.exports = {
   },
   unstable_runtimeJS: false,
   basePath: "/blog",
+  async rewrites() {
+    return [
+      {
+        source: `/`,
+        destination: `https://landing-page-prod.stately.ai`,
+        basePath: false,
+      },
+    ];
+  },
 };


### PR DESCRIPTION
This change lets `/` to load landing page so that `/blog` rewrite load the blog. This will make sure our development flow aligns with the production flow.