### PR TITLE
Fix duplicate authors in `post:create`

### DIFF
--- a/content/posts/2019-11-13-no-disabling-a-button-is-not-app-logic.mdx
+++ b/content/posts/2019-11-13-no-disabling-a-button-is-not-app-logic.mdx
@@ -10,8 +10,7 @@ tags:
   - statecharts
   - state
   - business logic
-author:
-  - - David Khourshid
+author: David Khourshid
 excerpt: ""
 publishedAt: "2019-11-13"
 originalURL: "https://dev.to/davidkpiano/no-disabling-a-button-is-not-app-logic-598i"

--- a/content/posts/2019-12-09-xstate-version-47-and-the-future.mdx
+++ b/content/posts/2019-12-09-xstate-version-47-and-the-future.mdx
@@ -10,8 +10,7 @@ tags:
   - statecharts
   - xstate
   - state
-author:
-  - - David Khourshid
+author: David Khourshid
 excerpt: ""
 publishedAt: "2019-12-09"
 originalURL: "https://dev.to/davidkpiano/xstate-version-4-7-and-the-future-2ehk"

--- a/content/posts/2020-07-27-state-machines-how-to-stop-making-horcruxes-in-your-code.mdx
+++ b/content/posts/2020-07-27-state-machines-how-to-stop-making-horcruxes-in-your-code.mdx
@@ -8,8 +8,7 @@ tags:
   - xstate
   - statechart
   - useReducer
-author:
-  - - Matt Pocock
+author: Matt Pocock
 excerpt: ""
 publishedAt: "2020-07-27"
 originalURL: "https://dev.to/mpocock1/state-machines-how-to-stop-making-horcruxes-in-your-code-gl5"

--- a/content/posts/2021-01-11-just-use-props-an-opinionated-guide-to-react-and-xstate.mdx
+++ b/content/posts/2021-01-11-just-use-props-an-opinionated-guide-to-react-and-xstate.mdx
@@ -8,8 +8,7 @@ tags:
   - xstate
   - state machine
   - react
-author:
-  - Matt Pocock
+author: Matt Pocock
 excerpt: ""
 publishedAt: "2021-01-11"
 originalURL: "https://dev.to/mpocock1/just-use-props-an-opinionated-guide-to-react-and-xstate-fc9"

--- a/content/posts/2021-01-20-you-dont-need-a-library-for-state-machines.mdx
+++ b/content/posts/2021-01-20-you-dont-need-a-library-for-state-machines.mdx
@@ -8,8 +8,7 @@ tags:
   - statecharts
   - xstate
   - state machine
-author:
-  - David Khourshid
+author: David Khourshid
 excerpt: ""
 publishedAt: "2021-01-20"
 originalURL: "https://dev.to/davidkpiano/you-don-t-need-a-library-for-state-machines-k7h"
@@ -187,11 +186,8 @@ This is much more succinct than the nested `switch` statements! From here, deter
 // ...
 function transition(state, event) {
   const nextStateNode = // lookup next finite state based on event type
-  // lookup configuration for current finite state
-  machine.states[state.status].on?.[
-    event.type
-  ] ?? // if not handled, stay on current state
-  { target: state.status };
+    // lookup configuration for current finite state
+    machine.states[state.status].on?.[event.type] ?? { target: state.status }; // if not handled, stay on current state
 
   return {
     ...state,

--- a/content/posts/2021-04-28-whats-the-difference-between-machine-and-createmachine.mdx
+++ b/content/posts/2021-04-28-whats-the-difference-between-machine-and-createmachine.mdx
@@ -7,8 +7,7 @@ description: >-
 tags:
   - typescript
   - state machines
-author:
-  - Matt Pocock
+author: Matt Pocock
 excerpt: ""
 publishedAt: "2021-04-28"
 originalURL: "https://dev.to/mpocock1/xstate-what-s-the-difference-between-machine-and-createmachine-15h1"

--- a/content/posts/2021-05-13-why-i-love-invoked-callbacks.mdx
+++ b/content/posts/2021-05-13-why-i-love-invoked-callbacks.mdx
@@ -8,8 +8,7 @@ tags:
   - invoked callback
   - state machines
   - xstate
-author:
-  - Matt Pocock
+author: Matt Pocock
 excerpt: ""
 publishedAt: "2021-05-13"
 originalURL: "https://dev.to/mpocock1/xstate-why-i-love-invoked-callbacks-2f6i"

--- a/content/posts/2021-07-28-usestate-vs-usereducer-vs-xstate-part-1-modals.mdx
+++ b/content/posts/2021-07-28-usestate-vs-usereducer-vs-xstate-part-1-modals.mdx
@@ -10,8 +10,7 @@ tags:
   - useState
   - useReducer
   - xstate
-author:
-  - Matt Pocock
+author: Matt Pocock
 excerpt: ""
 publishedAt: "2021-07-28"
 slug: usestate-vs-usereducer-vs-xstate-part-1-modals


### PR DESCRIPTION
The reason they were duplicate was that the author field in some posts was an array.