### PR TITLE
Disable lazily loading MDX content

### DIFF
--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -106,7 +106,7 @@ const PostPage: React.FC<{
             borderStyle="solid"
             borderColor="gray.700"
           >
-            <MDXRemote {...mdx} components={MDXComponents} lazy />
+            <MDXRemote {...mdx} components={MDXComponents} />
           </Box>
         </Box>
       </Layout>


### PR DESCRIPTION
This makes sure we have no intermediate empty state when loading a post, as reported by @Andarist 