### PR TITLE
Fix feeds urls

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -38,19 +38,19 @@ function MyApp({ Component, pageProps }: AppProps) {
           <link
             rel="alternate"
             type="application/rss+xml"
-            title="Subscribe to our blog feed"
+            title="Subscribe to Stately engineering blog"
             href="/blog/feeds/rss.xml"
           />
           <link
             rel="alternate"
             type="application/atom+xml"
-            title="Subscribe to our blog feed"
+            title="Subscribe to Stately engineering blog"
             href="/blog/feeds/atom.xml"
           />
           <link
             rel="alternate"
             type="application/feed+json"
-            title="Subscribe to our blog feed"
+            title="Subscribe to Stately engineering blog"
             href="/blog/feeds/feed.json"
           />
           <link rel="icon" href="/favicon.ico" sizes="any" />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -39,19 +39,19 @@ function MyApp({ Component, pageProps }: AppProps) {
             rel="alternate"
             type="application/rss+xml"
             title="Subscribe to our blog feed"
-            href="/feeds/rss.xml"
+            href="/blog/feeds/rss.xml"
           />
           <link
             rel="alternate"
             type="application/atom+xml"
             title="Subscribe to our blog feed"
-            href="/feeds/atom.xml"
+            href="/blog/feeds/atom.xml"
           />
           <link
             rel="alternate"
             type="application/feed+json"
             title="Subscribe to our blog feed"
-            href="/feeds/feed.json"
+            href="/blog/feeds/feed.json"
           />
           <link rel="icon" href="/favicon.ico" sizes="any" />
           <link rel="icon" href="/icon.svg" type="image/svg+xml" />


### PR DESCRIPTION
Tricky gotcha. Since we have rewrites to `/blog` to serve the blog homepage in the prod settings, any hard coded URL to an asset should be prefixed with`/blog`. This includes background images in the CSS and feed sources.

This PR:
- prefixes feed sources with `/blog`
- Uses blog title as feed source titles