### PR TITLE
Override og image

### DIFF
--- a/content/metadata.ts
+++ b/content/metadata.ts
@@ -4,6 +4,13 @@ export const DEFAULT_TITLE = "Stately Engineering Blog";
 export const DEFAULT_DESCRIPTION =
   "The official engineering blog of Stately.ai";
 export const DEFAULT_URL = "https://stately.ai/blog";
+export const DEFAULT_OG_IMAGE = {
+  url: "https://stately.ai/blog/og-image.png", // needs to be absolute URL
+  width: 0,
+  height: 0,
+  alt: DEFAULT_TITLE,
+  type: "image/png", // change based on actual OG image type
+};
 
 export const AUTHORS = [
   { name: "Farzad Yousefzadeh", twitterHandle: "@farzad_yz" },
@@ -20,6 +27,7 @@ export const makeMetadata = ({
   url = DEFAULT_URL,
   originalURL,
   article,
+  ogImage = DEFAULT_OG_IMAGE.url,
 }: MetadataOverrides | undefined = {}) => ({
   title,
   description,
@@ -34,11 +42,11 @@ export const makeMetadata = ({
     site_name: DEFAULT_TITLE,
     images: [
       {
-        url: "https://stately.ai/blog/og-image.png", // needs to be absolute URL
+        url: ogImage, // needs to be absolute URL
         width: 0,
         height: 0,
         alt: title,
-        type: "image/png", // change based on actual OG image type
+        type: "image/png",
       },
     ],
     article,

--- a/content/metadata.ts
+++ b/content/metadata.ts
@@ -45,7 +45,9 @@ export const makeMetadata = ({
         url: ogImage, // needs to be absolute URL
         width: 0,
         height: 0,
-        alt: title,
+        alt: `${title} by ${
+          article?.authors![0]
+        } on the Stately Engineering Blog`, // TODO: multiple authors
         type: "image/png",
       },
     ],

--- a/content/metadata.ts
+++ b/content/metadata.ts
@@ -45,9 +45,9 @@ export const makeMetadata = ({
         url: ogImage, // needs to be absolute URL
         width: 0,
         height: 0,
-        alt: `${title} by ${
+        alt: `‘${title}’ by ${
           article?.authors![0]
-        } on the Stately Engineering Blog`, // TODO: multiple authors
+        } on the Stately Engineering Blog.`, // TODO: multiple authors
         type: "image/png",
       },
     ],

--- a/content/posts/2019-11-13-no-disabling-a-button-is-not-app-logic.mdx
+++ b/content/posts/2019-11-13-no-disabling-a-button-is-not-app-logic.mdx
@@ -14,6 +14,7 @@ author: David Khourshid
 excerpt: ""
 publishedAt: "2019-11-13"
 originalURL: "https://dev.to/davidkpiano/no-disabling-a-button-is-not-app-logic-598i"
+ogImage: "https://stately.ai/blog/icon-512.png"
 ---
 
 I’m going to start this post with an excerpt from the book “Constructing the User Interface with Statecharts”, written by Ian Horrocks in 1999:

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -6,16 +6,12 @@ import { Layout } from "../src/components/Layout";
 import {
   Box,
   Heading,
-  Wrap,
   Button,
   UnorderedList,
   ListItem,
   Link as ChakraLink,
 } from "@chakra-ui/react";
-import {
-  ArrowBackIcon,
-  EditIcon
-} from "@chakra-ui/icons";
+import { ArrowBackIcon, EditIcon } from "@chakra-ui/icons";
 import { useRouter } from "next/router";
 import { MDXComponents } from "../src/components/MDXComponents";
 import { Seo } from "../src/Seo";
@@ -42,6 +38,7 @@ const PostPage: React.FC<{
           modifiedTime: post.updatedAt,
           tags: post.tags,
         }}
+        ogImage={post.ogImage}
       />
       <Layout posts={posts}>
         <Box
@@ -63,14 +60,15 @@ const PostPage: React.FC<{
           >
             All blog posts
           </Button>
-          <Heading size="xl" as="h1" fontWeight="medium" marginTop={{ base:"2", md:"7" }}>
+          <Heading
+            size="xl"
+            as="h1"
+            fontWeight="medium"
+            marginTop={{ base: "2", md: "7" }}
+          >
             {post.title}
           </Heading>
-          <Box
-            as="p"
-            marginTop="5"
-            color="gray.400"
-          >
+          <Box as="p" marginTop="5" color="gray.400">
             By&nbsp;
             <span>{post.author}</span>
             &nbsp;on&nbsp;
@@ -110,10 +108,7 @@ const PostPage: React.FC<{
             style={{ listStyleType: "none" }}
           >
             {post.tags.map((keyword) => (
-              <ListItem
-                key={keyword}
-                marginRight="1"
-              >{`#${keyword}`}</ListItem>
+              <ListItem key={keyword} marginRight="1">{`#${keyword}`}</ListItem>
             ))}
           </UnorderedList>
           <Box

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface PostFrontmatter {
   publishedAt: string;
   updatedAt?: string;
   originalURL?: string;
+  ogImage?: string;
 }
 
 export interface Post extends PostFrontmatter {
@@ -33,6 +34,7 @@ export type MetadataOverrides = Partial<{
   url: string;
   article: OpenGraphArticle;
   originalURL: string;
+  ogImage: string;
 }>;
 
 export type EmbedMode = "viz" | "panels" | "full";


### PR DESCRIPTION
This PR:
- Provide **an absolute URL** to an image in the post front matter
- That image will be provided as the OG image of the post in meta tags

Note: All images are assumed to exist in `/public` directory. That means we need to use them as `https://stately.ai/blog/[image_name].png` in the front matter.

@laurakalbag Anything you can think of to make this more productive?