### PR TITLE
Fix code formatting in "What’s new [...] for May 2022?"

### DIFF
--- a/content/posts/2022-05-03-whats-new-may-2022.mdx
+++ b/content/posts/2022-05-03-whats-new-may-2022.mdx
@@ -26,7 +26,7 @@ The new `waitFor(...)` helper function asynchronously waits for an actor’s emi
 
 Example usage:
 
-```
+```ts
 import { waitFor } from 'xstate/lib/waitFor';
 
 // ...


### PR DESCRIPTION
Here's the before/after:

![image](https://user-images.githubusercontent.com/6834140/169395488-b276a295-77d4-4148-a369-d19c562e3d4a.png)
